### PR TITLE
Add chat model helper and conversation history

### DIFF
--- a/services/ai_agent.py
+++ b/services/ai_agent.py
@@ -1,22 +1,33 @@
 from loguru import logger
 from langchain.chat_models import ChatOpenAI
 from langchain.schema import HumanMessage
+from langchain_core.language_models.chat_models import BaseChatModel
 import os
 
 try:
-    from langchain.llms import Ollama
-except Exception:
-    Ollama = None
+    from langchain_community.chat_models import ChatOllama
+except Exception:  # pragma: no cover - optional dependency
+    ChatOllama = None
+
+CONVERSATION_HISTORY: list[tuple[str, str]] = []
+
+
+def get_chat_model(model: str | None = None, temperature: float = 0.2) -> BaseChatModel:
+    """Return a chat model instance based on the configuration."""
+    model = model or os.environ.get("AI_MODEL", "openai")
+    if model == "openai":
+        llm: BaseChatModel = ChatOpenAI(temperature=temperature)
+    else:
+        if ChatOllama is None:
+            raise RuntimeError("ChatOllama not available")
+        llm = ChatOllama(model=model, temperature=temperature)
+    return llm
 
 
 def generate_patch(prompt: str, model: str | None = None, temperature: float = 0.2) -> str:
-    model = model or os.environ.get("AI_MODEL", "openai")
-    if model == "openai":
-        llm = ChatOpenAI(temperature=temperature)
-    else:
-        if Ollama is None:
-            raise RuntimeError("Ollama not installed")
-        llm = Ollama(model=model)
+    """Generate a git patch using the configured chat model."""
+    llm = get_chat_model(model=model, temperature=temperature)
     logger.info("Querying LLM for patch generation")
-    result = llm.invoke(HumanMessage(content=prompt))
-    return result.content
+    message = llm.invoke(HumanMessage(content=prompt))
+    CONVERSATION_HISTORY.append((prompt, message.content))
+    return message.content


### PR DESCRIPTION
## Summary
- refactor `ai_agent` to expose `get_chat_model` returning a `BaseChatModel`
- log conversations in `CONVERSATION_HISTORY`
- reuse the helper in `GenerateCode`

## Testing
- `ruff check nodes/generate_code.py services/ai_agent.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*

------
https://chatgpt.com/codex/tasks/task_e_688c73fd1fb8832588af47a33166a77a