### PR TITLE
Add Flyte deployment tools

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.10-slim
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY . .
+ENV PYTHONPATH=/app
+
+# Expose Flyte tasks when this image is used by pyflyte
+ENTRYPOINT ["bash"]

--- a/README.md
+++ b/README.md
@@ -58,4 +58,18 @@ L'agent écrit toujours le patch généré dans un fichier temporaire et exécut
 En cas d'échec de cette validation, le patch est ignoré et l'erreur est
 journalisée avec Loguru.
 
+## 📦 Déploiement Flyte
+
+Pour enregistrer les workflows sur votre cluster local :
+
+```bash
+./scripts/deploy_flyte.sh
+```
+
+Une fois publiés, le workflow d'exemple peut s'exécuter avec :
+
+```bash
+pyflyte run flyte/workflows/auto_commit.py auto_commit_workflow --repo_path /chemin/du/repo
+```
+
 

--- a/scripts/deploy_flyte.sh
+++ b/scripts/deploy_flyte.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Build container and register Flyte workflows
+set -euo pipefail
+
+IMAGE_NAME=${IMAGE_NAME:-agent-ai:latest}
+
+# Build Docker image containing the Flyte tasks
+docker build -t "$IMAGE_NAME" -f Dockerfile .
+
+# Register all workflows using pyflyte
+pyflyte --pkgs flyte,services.workflow register --image "$IMAGE_NAME"


### PR DESCRIPTION
## Summary
- add Dockerfile with dependencies for Flyte
- add `scripts/deploy_flyte.sh` to build/register workflows
- document Flyte deployment and execution steps

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*


------
https://chatgpt.com/codex/tasks/task_e_688c7d5eb5c4832588f7b626f35f73c7