### PR TITLE
Add initial test suite and CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,17 @@
+name: CI
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run tests
+        run: pytest

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -vv
+testpaths = tests

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1,0 +1,31 @@
+import os
+from pathlib import Path
+from git import Repo
+import pytest
+
+from services.git_ops import create_branch, commit_all, repo_diff
+
+
+def init_repo(path: Path) -> Repo:
+    repo = Repo.init(path)
+    (path / "README.md").write_text("init")
+    repo.git.add(all=True)
+    repo.index.commit("init")
+    return repo
+
+
+def test_create_branch(tmp_path):
+    repo = init_repo(tmp_path)
+    branch = create_branch(repo, "Add feature")
+    assert repo.active_branch.name == branch
+    assert branch.startswith("feat/")
+
+
+def test_commit_all_and_diff(tmp_path):
+    repo = init_repo(tmp_path)
+    (tmp_path / "file.txt").write_text("change")
+    commit_all(repo, "update")
+    assert repo.head.commit.message.strip() == "update"
+    assert repo_diff(repo) == ""
+    (tmp_path / "file.txt").write_text("new change")
+    assert repo_diff(repo) != ""

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+from git import Repo
+from nodes.classify_intent import ClassifyIntent
+from nodes.apply_changes import ApplyChanges
+from nodes.commit_and_push import CommitAndPush
+from nodes.explore_repo import ExploreRepo
+from nodes.generate_plan import GeneratePlan
+from nodes.generate_code import GenerateCode
+from nodes.validate import Validate
+
+class DummyLLM:
+    def __init__(self, response: str = ""):
+        self.response = response
+    def invoke(self, msg):
+        class M:
+            content = self.response
+        return M()
+
+def init_repo(path: Path) -> Repo:
+    repo = Repo.init(path)
+    (path / "README.md").write_text("init")
+    repo.git.add(all=True)
+    repo.index.commit("init")
+    return repo
+
+def test_classify_intent():
+    node = ClassifyIntent()
+    ctx = node.run({"goal": "Corriger un bug"})
+    assert ctx["intent"] == "bugfix"
+
+
+def test_apply_changes(tmp_path):
+    repo = init_repo(tmp_path)
+    file = tmp_path / "file.txt"
+    file.write_text("a\n")
+    repo.git.add(all=True)
+    repo.index.commit("add file")
+    diff = repo.git.diff('HEAD')
+    patch = f"--- a/file.txt\n+++ b/file.txt\n@@\n-a\n+b\n"
+    node = ApplyChanges()
+    ctx = {"repo": repo, "repo_path": str(tmp_path), "generated_patch": patch}
+    result = node.run(ctx)
+    assert "apply_error" not in result
+    assert file.read_text() == "b\n"
+
+
+def test_commit_and_push(tmp_path):
+    repo = init_repo(tmp_path / "src")
+    bare = Repo.init(tmp_path / "remote", bare=True)
+    repo.create_remote('origin', str(bare.working_tree_dir))
+    branch = repo.active_branch.name
+    node = CommitAndPush("msg")
+    ctx = {"repo": repo, "branch_name": branch}
+    result = node.run(ctx)
+    assert bare.refs[branch].commit.hexsha == repo.head.commit.hexsha
+
+
+def test_explore_repo(tmp_path):
+    src = init_repo(tmp_path / "src")
+    node = ExploreRepo(str(src.working_tree_dir))
+    ctx = node.run({"goal": "Test"})
+    assert Path(ctx["repo_path"]).exists()
+    assert ctx["branch_name"].startswith("feat/")
+    assert len(ctx["repo_files"]) > 0
+
+
+def test_generate_plan():
+    node = GeneratePlan()
+    ctx = node.run({"goal": "Anything"})
+    assert len(ctx["plan"]) == 4
+
+
+def test_generate_code(monkeypatch):
+    monkeypatch.setattr('services.ai_agent.get_chat_model', lambda model=None: DummyLLM("patch"))
+    node = GenerateCode()
+    ctx = node.run({"goal": "change"})
+    assert ctx["generated_patch"] == "patch"
+
+
+def test_validate(tmp_path):
+    repo = init_repo(tmp_path)
+    node = Validate()
+    ctx = node.run({"repo_path": str(tmp_path)})
+    assert ctx["validation_result"] == "success"


### PR DESCRIPTION
## Summary
- add tests for git operations
- create unit tests for nodes
- configure pytest
- run tests in GitHub Actions

## Testing
- `pytest -q` *(fails: No module named 'git')*

------
https://chatgpt.com/codex/tasks/task_e_688c851020bc8325a713639a8c0f78c7