### PR TITLE
Update setup for flytectl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ langgraph
 flytekit>=1.10
 flytekitplugins-envd
 flyteidl
-pyflyte
 fastapi
 uvicorn
 GitPython

--- a/setup.sh
+++ b/setup.sh
@@ -4,6 +4,8 @@ python3 -m venv .venv
 source .venv/bin/activate
 pip install --upgrade pip
 pip install -r requirements.txt
+curl -sL https://raw.githubusercontent.com/flyteorg/flytectl/master/install.sh | bash
+export PATH="$HOME/.flyte/bin:$PATH"
 if [ -f .env ]; then
   set -a
   source .env


### PR DESCRIPTION
## Summary
- remove `pyflyte` from Python requirements
- install `flytectl` and export its path in `setup.sh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'git')*

------
https://chatgpt.com/codex/tasks/task_e_688cc2b8ff248325818d7b88ea0de720