### PR TITLE
refactor tests and add repo helper

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+

--- a/tests/test_git_ops.py
+++ b/tests/test_git_ops.py
@@ -1,27 +1,18 @@
-import os
 from pathlib import Path
-from git import Repo
-import pytest
 
 from services.git_ops import create_branch, commit_all, repo_diff
 
-
-def init_repo(path: Path) -> Repo:
-    repo = Repo.init(path)
-    (path / "README.md").write_text("init")
-    repo.git.add(all=True)
-    repo.index.commit("init")
-    return repo
+from tests.utils import init_repo
 
 
-def test_create_branch(tmp_path):
+def test_create_branch_generates_feature_branch(tmp_path):
     repo = init_repo(tmp_path)
     branch = create_branch(repo, "Add feature")
     assert repo.active_branch.name == branch
     assert branch.startswith("feat/")
 
 
-def test_commit_all_and_diff(tmp_path):
+def test_commit_all_and_repo_diff(tmp_path):
     repo = init_repo(tmp_path)
     (tmp_path / "file.txt").write_text("change")
     commit_all(repo, "update")
@@ -29,3 +20,4 @@ def test_commit_all_and_diff(tmp_path):
     assert repo_diff(repo) == ""
     (tmp_path / "file.txt").write_text("new change")
     assert repo_diff(repo) != ""
+

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+
 from git import Repo
+
 from nodes.classify_intent import ClassifyIntent
 from nodes.apply_changes import ApplyChanges
 from nodes.commit_and_push import CommitAndPush
@@ -8,35 +10,37 @@ from nodes.generate_plan import GeneratePlan
 from nodes.generate_code import GenerateCode
 from nodes.validate import Validate
 
+from tests.utils import init_repo
+
+
 class DummyLLM:
     def __init__(self, response: str = ""):
         self.response = response
+
     def invoke(self, msg):
         class M:
             content = self.response
+
         return M()
 
-def init_repo(path: Path) -> Repo:
-    repo = Repo.init(path)
-    (path / "README.md").write_text("init")
-    repo.git.add(all=True)
-    repo.index.commit("init")
-    return repo
 
-def test_classify_intent():
+def test_classify_intent_bugfix():
     node = ClassifyIntent()
     ctx = node.run({"goal": "Corriger un bug"})
     assert ctx["intent"] == "bugfix"
 
 
-def test_apply_changes(tmp_path):
+def test_apply_changes_applies_patch(tmp_path):
     repo = init_repo(tmp_path)
     file = tmp_path / "file.txt"
     file.write_text("a\n")
     repo.git.add(all=True)
     repo.index.commit("add file")
-    diff = repo.git.diff('HEAD')
-    patch = f"--- a/file.txt\n+++ b/file.txt\n@@\n-a\n+b\n"
+    file.write_text("b\n")
+    patch = repo.git.diff("HEAD")
+    if not patch.endswith("\n"):
+        patch += "\n"
+    repo.git.checkout("--", str(file))
     node = ApplyChanges()
     ctx = {"repo": repo, "repo_path": str(tmp_path), "generated_patch": patch}
     result = node.run(ctx)
@@ -44,41 +48,42 @@ def test_apply_changes(tmp_path):
     assert file.read_text() == "b\n"
 
 
-def test_commit_and_push(tmp_path):
+def test_commit_and_push_creates_remote_branch(tmp_path):
     repo = init_repo(tmp_path / "src")
     bare = Repo.init(tmp_path / "remote", bare=True)
-    repo.create_remote('origin', str(bare.working_tree_dir))
-    branch = repo.active_branch.name
+    repo.create_remote("origin", str(bare.git_dir))
+    (Path(repo.working_tree_dir) / "change.txt").write_text("content")
     node = CommitAndPush("msg")
-    ctx = {"repo": repo, "branch_name": branch}
-    result = node.run(ctx)
-    assert bare.refs[branch].commit.hexsha == repo.head.commit.hexsha
+    ctx = {"repo": repo, "branch_name": repo.active_branch.name}
+    node.run(ctx)
+    assert bare.refs[repo.active_branch.name].commit.hexsha == repo.head.commit.hexsha
 
 
-def test_explore_repo(tmp_path):
+def test_explore_repo_gathers_repository_info(tmp_path):
     src = init_repo(tmp_path / "src")
     node = ExploreRepo(str(src.working_tree_dir))
     ctx = node.run({"goal": "Test"})
     assert Path(ctx["repo_path"]).exists()
     assert ctx["branch_name"].startswith("feat/")
-    assert len(ctx["repo_files"]) > 0
+    assert ctx["repo_files"]
 
 
-def test_generate_plan():
+def test_generate_plan_returns_four_steps():
     node = GeneratePlan()
     ctx = node.run({"goal": "Anything"})
     assert len(ctx["plan"]) == 4
 
 
-def test_generate_code(monkeypatch):
-    monkeypatch.setattr('services.ai_agent.get_chat_model', lambda model=None: DummyLLM("patch"))
+def test_generate_code_uses_dummy_llm(monkeypatch):
+    monkeypatch.setattr("nodes.generate_code.get_chat_model", lambda model=None: DummyLLM("patch"))
     node = GenerateCode()
     ctx = node.run({"goal": "change"})
     assert ctx["generated_patch"] == "patch"
 
 
-def test_validate(tmp_path):
+def test_validate_runs_pytest_success(tmp_path):
     repo = init_repo(tmp_path)
     node = Validate()
     ctx = node.run({"repo_path": str(tmp_path)})
     assert ctx["validation_result"] == "success"
+

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+
+from git import Repo
+
+
+def init_repo(path: Path, default_branch: str = "main") -> Repo:
+    repo = Repo.init(path, initial_branch=default_branch)
+    (path / "README.md").write_text("init")
+    repo.git.add(all=True)
+    repo.index.commit("init")
+    return repo
+


### PR DESCRIPTION
## Summary
- centralize git repo initialization in tests with `init_repo`
- repair patch application, branch creation, and mock LLM initialization
- ensure test suite can import project modules reliably

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f0d96e44c8325b4d0e7b713a181f9