### PR TITLE
Run pytest during validation and add failure tests

### DIFF
--- a/nodes/validate.py
+++ b/nodes/validate.py
@@ -1,16 +1,24 @@
 from loguru import logger
 from flytekit import task, workflow
+from pathlib import Path
+import subprocess
 
 
 @task
-def run_tests(repo_path: str) -> str:
-    # Placeholder for real validation commands
+def run_tests(repo_path: str) -> dict:
+    """Run pytest in the given repository and save the report."""
     logger.info(f"Running tests in {repo_path}")
-    return "success"
+    report_path = Path(repo_path) / "pytest_report.txt"
+    result = subprocess.run(
+        ["pytest", "-q"], cwd=repo_path, capture_output=True, text=True
+    )
+    report_path.write_text(result.stdout + result.stderr)
+    status = "success" if result.returncode == 0 else "failure"
+    return {"status": status, "report": str(report_path)}
 
 
 @workflow
-def validation_workflow(repo_path: str) -> str:
+def validation_workflow(repo_path: str) -> dict:
     return run_tests(repo_path=repo_path)
 
 

--- a/tests/test_nodes.py
+++ b/tests/test_nodes.py
@@ -83,7 +83,18 @@ def test_generate_code_uses_dummy_llm(monkeypatch):
 
 def test_validate_runs_pytest_success(tmp_path):
     repo = init_repo(tmp_path)
+    (tmp_path / "test_sample.py").write_text("def test_ok():\n    assert True\n")
     node = Validate()
     ctx = node.run({"repo_path": str(tmp_path)})
-    assert ctx["validation_result"] == "success"
+    assert ctx["validation_result"]["status"] == "success"
+    assert Path(ctx["validation_result"]["report"]).exists()
+
+
+def test_validate_runs_pytest_failure(tmp_path):
+    repo = init_repo(tmp_path)
+    (tmp_path / "test_fail.py").write_text("def test_fail():\n    assert False\n")
+    node = Validate()
+    ctx = node.run({"repo_path": str(tmp_path)})
+    assert ctx["validation_result"]["status"] == "failure"
+    assert Path(ctx["validation_result"]["report"]).exists()
 


### PR DESCRIPTION
## Summary
- invoke pytest in validation workflow and write report
- return structured test status and report path
- add unit tests for both passing and failing scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6891b2d227908325afddc1163cde9353